### PR TITLE
Explicitly pass bytes to the LDAP library and return unicode

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 
 TEAM_PREFIX = 'team-'
 COLLEGE_PREFIX = 'college-'

--- a/sr_ldap.py
+++ b/sr_ldap.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 try:
     from ConfigParser import NoOptionError
@@ -36,7 +36,7 @@ def ensure_bytes(data):
 def connect():
     global conn
     conn_str = "ldap://%s/" % config.get('ldap', 'host')
-    conn = ldap.initialize(conn_str)
+    conn = ldap.initialize(conn_str, bytes_mode=False)
 
 if conn == None:
     connect()
@@ -56,7 +56,7 @@ def default_pass():
     else:
         conn_str = "uid={0},ou=users,o=sr".format(username)
 
-    return (conn_str, passwd)
+    return (conn_str, ensure_text(passwd))
 
 user_callback = default_pass
 

--- a/users.py
+++ b/users.py
@@ -30,7 +30,7 @@ def list():
                                   ldap.SCOPE_ONELEVEL,
                                   filterstr = "(objectClass=inetOrgPerson)",
                                   attrlist = ["uid"] )
-    users = [x[1]["uid"][0] for x in u_res]
+    users = ensure_text([x[1]["uid"][0] for x in u_res])
 
     return users
 
@@ -120,7 +120,7 @@ class user:
                                       filterstr = filter_str,
                                       attrlist = ["uid"])
 
-        userids = [item[1][u'uid'][0] for item in result]
+        userids = ensure_text([item[1][u'uid'][0] for item in result])
         return userids
 
     @classmethod


### PR DESCRIPTION
This makes working with Python 3 easier as the types are much more clearly defined.

Contributes towards https://github.com/srobo/nemesis/issues/5.

~I've not yet explored what impact this has on https://github.com/srobo/userman, so this is blocked on that.~